### PR TITLE
Config additions: "Cascade" & "Mandatory"

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,6 @@
+.hide{
+    display:none;
+}
 .gf-map {
     width: 100%;
     height: 300px;

--- a/js/main.js
+++ b/js/main.js
@@ -115,7 +115,7 @@ define([
             // options object
             var options = {
                 map: this.map,
-                autoComplete: "hasEsri"
+                autoComplete: hasEsri
             };
             //If there is a valid search id and field defined add the feature layer to the geocoder array
             var searchLayers = [];

--- a/js/main.js
+++ b/js/main.js
@@ -638,7 +638,6 @@ define([
         },
         //function to validate and create the form
         _createForm: function (fields) {
-            this._questionDisplayControl();
             domConstruct.empty(dom.byId('userForm'));
             this.sortedFields = [];
             var formContent, labelContent, matchingField, newAddedFields = [], userFormNode;

--- a/js/main.js
+++ b/js/main.js
@@ -400,14 +400,14 @@ define([
         },
         _questionDisplayControl: function(){
           var _affirmativeFormFields = [],
-          _neggativeFormFields = [],
+          _negativeFormFields = [],
           app = this,
           _compileCascadeFields = function(){
             $.each(app._formLayer.fields, function(i, v){
               if (v.cascade === 'affirmative'){
                 _affirmativeFormFields.push(v.name)  
-              }else if (v.cascade === 'neggative'){
-                _neggativeFormFields.push(v.name)  
+              }else if (v.cascade === 'negative'){
+                _negativeFormFields.push(v.name)  
               } 
             }); 
           };
@@ -423,8 +423,8 @@ define([
            });
          },
           //Hide all questions below the current question if response is 'no'
-          _neggativeHideQuestionsBelow = function(){
-            $.each(_neggativeFormFields, function(n, id){
+          _negativeHideQuestionsBelow = function(){
+            $.each(_negativeFormFields, function(n, id){
               if($('#' + id + 'No').is(':checked')) { 
                 $( ".geoFormQuestionare" ).has( '[id^="' + id + '"]' ).nextAll().addClass( "hide" )
               } else if($('#' + id + 'Yes').is(':checked')) { 
@@ -438,7 +438,7 @@ define([
                 _compileCascadeFields();
                 $('body').on('click', function(){
                   _affirmativeHideQuestionsBelow();
-                  _neggativeHideQuestionsBelow(); 
+                  _negativeHideQuestionsBelow(); 
                 }) 
                 clearInterval(intervalCheck);
               }

--- a/js/main.js
+++ b/js/main.js
@@ -115,7 +115,7 @@ define([
             // options object
             var options = {
                 map: this.map,
-                autoComplete: true //djacosta edit "true" from "hasEsri"
+                autoComplete: "hasEsri"
             };
             //If there is a valid search id and field defined add the feature layer to the geocoder array
             var searchLayers = [];


### PR DESCRIPTION
I added a couple of features to the form that can be modified in the "fields" object within the default config:

## cascade
"cascade" controls the visibility of fields in the form. Any questions that follow a true/false radio field can be hidden using the following arguments:

* "affirmative", if all fields should disappear if the response is "Yes".
* "negative", if all fields should disappear if the response is "No".

## mandatory
"mandatory": true will make the field mandatory if it is visible. If it is hidden by the cascade, then the 'mandatory' class will be removed.